### PR TITLE
Add FlattenRootFolder option to extract files from root directory

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.NET.csproj
+++ b/AutoUpdater.NET/AutoUpdater.NET.csproj
@@ -31,6 +31,11 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+        <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    </PropertyGroup>
+
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DebugType>pdbonly</DebugType>
     </PropertyGroup>
@@ -38,6 +43,7 @@
         <DebugType>full</DebugType>
     </PropertyGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+        <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
         <Reference Include="System"/>
         <Reference Include="System.Data"/>
         <Reference Include="System.Drawing"/>

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -132,6 +132,11 @@ public static class AutoUpdater
     public static bool ClearAppDirectory = false;
 
     /// <summary>
+    ///     Set this to true if you want to flatten the root folder in zip file.
+    /// </summary>
+    public static bool FlattenRootFolder = false;
+
+    /// <summary>
     ///     Set it to folder path where you want to download the update file. If not provided then it defaults to Temp folder.
     /// </summary>
     public static string DownloadPath;
@@ -762,7 +767,7 @@ public static class AutoUpdater
         {
             basicAuthentication?.Apply(ref webClient);
 
-            webClient.Headers[HttpRequestHeader.UserAgent] = HttpUserAgent;
+            webClient.Headers[HttpRequestHeader.UserAgent] = GetUserAgent();
         }
 
         return webClient;

--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -221,6 +221,9 @@ internal partial class DownloadUpdateDialog : Form
                     arguments.Add(string.Join(" ", args.Skip(1).Select(arg => $"\"{arg}\"")));
                 }
 
+                if (AutoUpdater.FlattenRootFolder)
+                    arguments.Add("--flatten-root-folder");
+
                 processStartInfo.Arguments = Utils.BuildArguments(arguments);
             }
             else if (extension.Equals(".msi", StringComparison.OrdinalIgnoreCase))

--- a/AutoUpdaterTest/MainWindow.xaml.cs
+++ b/AutoUpdaterTest/MainWindow.xaml.cs
@@ -173,11 +173,16 @@ public partial class MainWindow : Window
         // Uncomment following line to change the Icon shown on the updater dialog.
         AutoUpdater.Icon = Resource.Icon;
 
+        // Uncomment following line to disable automatic loading of changelog extensions.
+        //AutoUpdater.AutoLoadExtensions = false;
+
+        // Uncomment following line to extract the zip file without root folder.
+        //AutoUpdater.FlattenRootFolder = true;
+
         // Uncomment following line to change the Changelog viewer type.
         //AutoUpdater.ChangelogViewerProvider = new RichTextBoxViewerProvider();
 
         // Uncomment following lines to handle parsing logic of custom AppCast file.
-        //AutoUpdater.HttpUserAgent = "AutoUpdaterTest";
         //AutoUpdater.ParseUpdateInfoEvent += p =>
         //{
         //    var json = JsonConvert.DeserializeObject<dynamic>(p.RemoteData);

--- a/README.md
+++ b/README.md
@@ -334,6 +334,24 @@ to clear the application directory before extracting the update file using the b
 AutoUpdater.ClearAppDirectory = true;
 ````
 
+### Flatten root folder when extracting zip file
+
+Sometimes zip files contain a root folder with all the application files inside it. If you want to extract the contents of this root folder directly to the application directory instead of creating the root folder in the application directory, you can use the `FlattenRootFolder` option:
+
+````csharp
+AutoUpdater.FlattenRootFolder = true;
+````
+This is particularly useful for zip files with structures like:
+```
+AppName.zip
+  └── AppName/
+      ├── executable.exe
+      ├── lib/
+      │   └── some.dll
+      └── data/
+          └── config.json
+```
+
 ### Specify size of the UpdateForm
 
 You can specify the size of the update form by using below code.

--- a/ZipExtractor/ZipExtractor.csproj
+++ b/ZipExtractor/ZipExtractor.csproj
@@ -9,10 +9,7 @@
         <Company>RBSoft</Company>
         <Product>ZipExtractor</Product>
         <Copyright>Copyright © 2012-2025 RBSoft</Copyright>
-        <Version>1.5.4.0</Version>
-        <AssemblyVersion>1.5.4.0</AssemblyVersion>
-        <FileVersion>1.5.4.0</FileVersion>
-        <ApplicationVersion>1.5.4.0</ApplicationVersion>
+        <Version>1.5.4.1</Version>
         <ApplicationIcon>ZipExtractor.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This commit adds a new feature that allows extracting files directly from a root folder in a zip file. When enabled, the ZipExtractor will detect if all files are contained within a common root directory and extract them directly to the destination path without creating the root directory structure.

Changes:
- Added new `--flatten-root-folder` command-line argument to ZipExtractor
- Added detection and handling of root folders in zip files
- Added `FlattenRootFolder` property to AutoUpdater class
- Updated DownloadUpdateDialog to pass the parameter to ZipExtractor
- Added documentation in README.md with examples

This feature is useful when zip files contain a single root folder with all application files inside, allowing for cleaner extraction without an extra directory level.

This is particularly useful for zip files with structures like:
```
AppName.zip
  └── AppName/
      ├── executable.exe
      ├── lib/
      │   └── some.dll
      └── data/
          └── config.json
```