### PR TITLE
Add an option to specify the saved file name to fix incorrect file name formatting.

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -125,7 +125,9 @@ internal partial class DownloadUpdateDialog : Form
                 }
             }
 
-            string fileName = string.IsNullOrEmpty(contentDisposition?.FileName)
+            string fileName = !string.IsNullOrEmpty(_args.DownloadFileName) 
+                ? _args.DownloadFileName: 
+                string.IsNullOrEmpty(contentDisposition?.FileName)
                 ? Path.GetFileName(_webClient.ResponseUri.LocalPath)
                 : contentDisposition.FileName;
 

--- a/AutoUpdater.NET/UpdateInfoEventArgs.cs
+++ b/AutoUpdater.NET/UpdateInfoEventArgs.cs
@@ -19,6 +19,12 @@ public class UpdateInfoEventArgs : EventArgs
     }
 
     /// <summary>
+    ///     It will be prioritized if provided. Used in cases where the download URL does not contain a file name (e.g., Base64) or the header does not include Content-Disposition
+    /// </summary>
+    [XmlElement("filename")]
+    public string DownloadFileName { get; set; }
+
+    /// <summary>
     ///     If new update is available then returns true otherwise false.
     /// </summary>
     public bool IsUpdateAvailable { get; set; }


### PR DESCRIPTION
In some cases, updates need to be downloaded from URLs that do not contain a properly formatted file name.
For example:
https://example.com/download/aW90L2lvdHNvZnR3YXJlLzIwMjUvMDIvMjYvMTc0MDU3NDg1MjQ3OC56aXA=

In this case, the Content-Disposition header in the response must be used to determine the file name. However, if it is missing, the downloaded file will be saved as aW90L2lvdHNvZnR3YXJlLzIwMjUvMDIvMjYvMTc0MDU3NDg1MjQ3OC56aXA=, which can cause issues. For example, it may not be possible to extract the file (if it lacks a .zip extension) or execute it (if it lacks a .exe extension), leading to an update failure.

In this update, users can manually specify the desired file name using UpdateInfoEventArgs.DownloadFileName.
For example:
```
UpdateInfoEventArgs.DownloadFileName = "Update.zip";
```